### PR TITLE
replace the strsplit() with custom split_arg()

### DIFF
--- a/dgea.R
+++ b/dgea.R
@@ -91,17 +91,24 @@ argv   <- parse_args(parser)
 #############################################################################
 #                        Command Line Arguments Retrieval                   #
 #############################################################################
+split_arg <- function(vector_arg) {
+  pos <- unlist(gregexpr("[^\\\\],", vector_arg, perl=TRUE))
+  vect <- substring(vector_arg, c(1, pos+2), c(pos, nchar(vector_arg)))
+  vect <- gsub("\\\\,", ",", vect) # replace \\, with ,
+  vect <- gsub("\\\"", '"', vect) #replace \" with "
+  return (vect)
+}
 
 # General Parameters
 run.dir         <- argv$rundir
 dbrdata         <- argv$dbrdata
-analysis.list   <- unlist(strsplit(argv$analyse, ","))
+analysis.list   <- split_arg(argv$analyse)
 
 # Sample Parameters
 accession       <- argv$accession
 factor.type     <- argv$factor
-population1     <- unlist(strsplit(argv$popA, ","))
-population2     <- unlist(strsplit(argv$popB, ","))
+population1     <- split_arg(argv$popA)
+population2     <- split_arg(argv$popB)
 pop.name1       <- argv$popname1
 pop.name2       <- argv$popname2
 pop.colour1     <- "#b71c1c"  # Red

--- a/gage.R
+++ b/gage.R
@@ -81,6 +81,13 @@ argv <- parse_args(parser)
 # #############################################################################
 #                         Command Line Arguments Retrieval                   #
 # #############################################################################
+split_arg <- function(vector_arg) {
+  pos <- unlist(gregexpr("[^\\\\],", vector_arg, perl=TRUE))
+  vect <- substring(vector_arg, c(1, pos+2), c(pos, nchar(vector_arg)))
+  vect <- gsub("\\\\,", ",", vect) # replace \\, with ,
+  vect <- gsub("\\\"", '"', vect) #replace \" with "
+  return (vect)
+}
 
 # General Parameters
 rundir          <- argv$rundir
@@ -90,8 +97,8 @@ isdebug         <- ifelse(!is.na(argv$dev), argv$dev, FALSE)
 # Sample Parameters
 accession   <- argv$accession
 factor.type <- as.character(argv$factor)
-population1 <- unlist(strsplit(argv$popA, ","))
-population2 <- unlist(strsplit(argv$popB, ","))
+population1 <- split_arg(argv$popA)
+population2 <- split_arg(argv$popB)
 
 pop.colour1     <- "#b71c1c"  # Red
 pop.colour2     <- "#0d47a1"  # Blue

--- a/overview.R
+++ b/overview.R
@@ -62,17 +62,23 @@ argv   <- parse_args(parser)
 #############################################################################
 #                        Command Line Arguments Retrieval                   #
 #############################################################################
+split_arg <- function(vector_arg) {
+  pos <- unlist(gregexpr("[^\\\\],", vector_arg, perl=TRUE))
+  vect <- substring(vector_arg, c(1, pos+2), c(pos, nchar(vector_arg)))
+  vect <- gsub("\\\\,", ",", vect) # replace \\, with ,
+  vect <- gsub("\\\"", '"', vect) #replace \" with "
+  return (vect)
+}
 
 # General Parameters
 run.dir         <- argv$rundir
 dbrdata         <- argv$dbrdata
-accession       <- argv$accession
-analysis.list   <- unlist(strsplit(argv$analyse, ","))
+analysis.list   <- split_arg(argv$analyse)
 
 # Sample Parameters
 factor.type     <- argv$factor
-population1     <- unlist(strsplit(argv$popA, ","))
-population2     <- unlist(strsplit(argv$popB, ","))
+population1     <- split_arg(argv$popA)
+population2     <- split_arg(argv$popB)
 pop.name1       <- argv$popname1
 pop.name2       <- argv$popname2
 pop.colour1     <- "#e199ff" # Purple


### PR DESCRIPTION
Fixes a few bugs due to the populations containing `,`.


See #103 